### PR TITLE
:label: fix(types): Improved types for `createStoreUpdater`

### DIFF
--- a/src/createStoreUpdater.ts
+++ b/src/createStoreUpdater.ts
@@ -13,17 +13,22 @@ declare type WithoutCallSignature<T> = {
  *  @param  deps：依赖项数组，默认为 [value]
  *  @param  setStoreState：一个可选的回调函数，用于更新 Store 状态
  */
-export type UseStoreUpdater<T> = (
-  key: keyof T,
-  value: any,
+export type UseStoreUpdater<T> = <Key extends keyof T>(
+  key: Key,
+  value: T[Key],
   deps?: any[],
-  setStateFn?: (state: T) => void,
+  setStateFn?: StoreApi<T>['setState'],
 ) => void;
 
 // 定义一个函数，用于创建 Store 更新器
 export const createStoreUpdater =
   <T>(storeApi: WithoutCallSignature<StoreApi<T>>): UseStoreUpdater<T> =>
-  (key, value, deps = [value], setStateFn) => {
+  <Key extends keyof T>(
+    key: Key,
+    value: T[Key],
+    deps = [value],
+    setStateFn?: StoreApi<T>['setState'],
+  ) => {
     // 获取 Store 更新函数
     const setState = setStateFn ?? storeApi.setState;
     // 使用 useEffect 监听依赖项变化
@@ -35,7 +40,7 @@ export const createStoreUpdater =
 
         // @ts-ignore
         setState({ [key]: value }, false, {
-          type: `💭 useStoreUpdater / ${key as string}`,
+          type: `💭 useStoreUpdater / ${key.toString()}`,
           payload: value,
         });
       }


### PR DESCRIPTION
`createStoreUpdater` now restricts the type of the value to the type of the value associated with that key

```ts
import { createStoreUpdater } from 'zustand-utils';
import { create } from 'zustand';

interface User {
  name: string;
  age: number;
}

const storeApi = create<User>(() => ({ name: '', age: 0 }));
const updateUser = createStoreUpdater(storeApi);

// == BEFORE this type update ==
updateUser('age', '18'); //  ✅ This is fine (accepts incorrect type as value)
updateUser('age', 18); // ✅ Correct type


// == AFTER this type update ==
updateUser('age', '18'); // ❌ Error: Argument of type 'string' is not assignable to parameter of type 'number'.
updateUser('age', 18); // ✅ Correct type
```